### PR TITLE
typo squashing in Lab 11 AK

### DIFF
--- a/Instructions/20347A_LAB_AK_11.md
+++ b/Instructions/20347A_LAB_AK_11.md
@@ -42,7 +42,7 @@
   ```
 
   >  **Note:** Depending on the location of your tenant, replace the link in the preceding command with one of the following:
-  >  - For Europe: https://sp-rms.na.aadrm.com/TenantManagement/ServicePartner.svc
+  >  - For North America: https://sp-rms.na.aadrm.com/TenantManagement/ServicePartner.svc
   >  - For Asia: https://sp-rms.ap.aadrm.com/TenantManagement/ServicePartner.svc
   >  - For South America: https://sp-rms.sa.aadrm.com/TenantManagement/ServicePartner.svc 
   >  You can check the tenant location by running the command **Get-MsolCompanyInformation | Select ReplicationScope** after connecting to the tenant using **Connect-MsolService**. If the IRM sharing location does not match your region, you will receive an error in the next step.
@@ -90,7 +90,7 @@
   
 1. On LON-CL1, open Word 2016. 
 
-2. In the Word window, at the top right corner, click  **Switch account** or ** Sign in**.
+2. In the Word window, at the top right corner, click  **Switch account** or **Sign in**.
 
 3. In the Accounts dialog box, click  **Add Account**.
 
@@ -102,7 +102,7 @@
 
 7. On LON-CL1, open Microsoft Outlook 2016. 
 
-8. Create a new email with  **Beth** **Burke** as the recipient.
+8. Create a new email with  **Beth Burke** as the recipient.
 
 9. Type a subject, and then type some text in the message body.
 
@@ -246,7 +246,7 @@
 
 5. Under **compliance management**, click  **retention tags**.
 
-6. On  the **retention Tags** page, click **New tag**, which is the plus sign ( **+**), and then select  **applied automatically to entire mailbox (default)**.
+6. On  the **retention Tags** page, click **New tag**, which is the plus sign (**+**), and then select  **applied automatically to entire mailbox (default)**.
 
 7. Type  **Research User 1 year move to archive** as the name.
 


### PR DESCRIPTION
couple of misplaced spaces, and the line in the note for Exchange IRM setup for the correct address for North America said "Europe".