### PR TITLE
Change login.msonline.com to portal.office.com, domain name, typos

### DIFF
--- a/Instructions/20347A_LAB_AK_07.md
+++ b/Instructions/20347A_LAB_AK_07.md
@@ -7,9 +7,9 @@
   
 1. On the taskbar, click  **Microsoft Edge**.
 
-2. In Microsoft Edge, in the  **search** box, type **https://login.microsoftonline.com**, and press Enter.
+2. In Microsoft Edge, in the  **search** box, type **https://portal.office.com**, and press Enter.
 
-3. At the login page, sign in as  **Holly@yourdomain.hostdomain.com** with the password **Pa55w.rd**.
+3. At the login page, sign in as  **Holly@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, with the password **Pa55w.rd**.
 
 4. To open the Office 365 admin center, click  **Admin**.
 
@@ -99,15 +99,15 @@
 
 16. On LON-CL2, on the taskbar, click  **Microsoft Edge**.
 
-17. In Microsoft Edge, in the  **search** box, type **https://login.microsoftonline.com**, and then press Enter.
+17. In Microsoft Edge, in the  **search** box, type **https://portal.office.com**, and then press Enter.
 
-18. Sign in as  **Francisco@yourdomain.hostdomain.com** with the password **Pa55w.rd**.
+18. Sign in as  **Francisco@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, with the password **Pa55w.rd**.
 
 19. In Office 365, click  **Mail**.
 
 20. In the Mail window, click  **New**.
 
-21. In the  **To** field, typealias@outlook.com, where alias@outlook.com is the Microsoft account that you configured at the beginning of this course.
+21. In the  **To** field, type **alias@outlook.com**, where alias@outlook.com is the Microsoft account that you configured at the beginning of this course.
 
 22. In the  **Subject** field, type **Disclaimer Test**.
 
@@ -125,7 +125,7 @@
 
 29. On LON-CL1, click  **Start**, type  **Outlook**, and then click  **Outlook 2016**. 
 
-30. Type  **Holly@yourdomain.hostdomain.com** and **Pa55w.rd** in the Windows Security dialog box.
+30. Type  **Holly@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, and **Pa55w.rd** in the Windows Security dialog box.
 
 31. In Outlook, read the approval request, and then click  **Approve**.
 
@@ -194,11 +194,11 @@
 
 5. Select the  **Notify administrator about undelivered messages from internal senders** check box.
 
-6. In the  **Administrator email address** box, type **Holly@yourdomain.hostdomain.com**.
+6. In the  **Administrator email address** box, type **Holly@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number.
 
 7. Select the  **Notify administrator about undelivered messages from external senders** check box.
 
-8. In the  **Administrator email address** box, type **Holly@yourdomain.hostdomain.com**, and then click  **Save**.
+8. In the  **Administrator email address** box, type **Holly@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, and then click  **Save**.
 
 
 
@@ -248,19 +248,19 @@
   
 1. Sign in to your alias@outlook.com account.
 
-2. Create a new message to send to  **kendra@Yourdomain.hostdomain.com**.
+2. Create a new message to send to  **kendra@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number.
 
-3. In the body of the message, include the text  **XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X**, and then send the message.
+3. In the body of the message, include the text  **XJS\*C4JDBQADN1.NSBN3\*2IDNEN\*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL\*C.34X**, and then send the message.
 
-4. Create a new message to send to  **francisco@Yourdomain.hostdomain.com**.
+4. Create a new message to send to  **francisco@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number.
 
-5. In the body of the message, include the text  **XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X**, and then send the message.
+5. In the body of the message, include the text  **XJS\*C4JDBQADN1.NSBN3\*2IDNEN\*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL\*C.34X**, and then send the message.
 
 6. On LON-CL1, in the Exchange admin center, click  **protection**, and then click  **quarantine**.
 
 7. Verify that the message sent to Francisco is in quarantine, but the message sent to Kendra is not.
 
-8. Click the message sent to Francisco, click  **Release Message**, and then click  **Release selected message(s) to** **ALL** **recipients**.
+8. Click the message sent to Francisco, click  **Release Message**, and then click  **Release selected message(s) to ALL recipients**.
 
 9. In the Warning window, click  **Yes**.
 
@@ -282,7 +282,7 @@
 
 5. Under  **Safe attachments unknown malware response**, click  **Replace - Block the attachments with detected malware, continue to deliver the message**.
 
-6. Below  **AppliedTo** in the **If** box, select **The recipient is a member of**.
+6. Below  **Applied To** in the **If** box, select **The recipient is a member of**.
 
 7. In the  **Select Members** window, click **Sales**, click  **add**, and then click  **OK**.
 
@@ -314,21 +314,21 @@
 
 5. Under  **Private computer or OWA for devices**, clear the  **Direct file access** check box, and then click **Save**.
 
-6. Click  **recipients**, click ** mailboxes,** click **Kendra Sexton**, and then click  **Edit**.
+6. Click  **recipients**, click **mailboxes,** click **Kendra Sexton**, and then click  **Edit**.
 
 7. In the Kendra Sexton window, click  **mailbox features**.
 
-8. Under  **Email Connectivity**, click  **View** **details**.
+8. Under  **Email Connectivity**, click  **View details**.
 
 9. In the Outlook Web App mailbox policy window, click  **Browse**, click  **Limited features**, click  **OK**, and then click  **Save**.
 
 10. In the Kendra Sexton window, click  **Save**.
 
-11. On LON-CL1, click  **Start**, type  **Outlook** and then click **Outlook 2016**. If prompted, type  **Holly@yourdomain.hostdomain.com** and **Pa55w.rd** in the Windows Security dialog box.
+11. On LON-CL1, click  **Start**, type  **Outlook** and then click **Outlook 2016**. If prompted, type  **Holly@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, and **Pa55w.rd** in the Windows Security dialog box.
 
 12. Click  **New Email**.
 
-13. In the new email window, in the  **To** box, type **Kendra@yourdomain.hostdomain.com** and then click ** Check Names**.
+13. In the new email window, in the  **To** box, type **Kendra@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, and then click **Check Names**.
 
 14. In the  **Subject** box, type **Attachment Test**.
 
@@ -338,7 +338,7 @@
 
 17. Click  **Send**.
 
-18. On LON-CL2, in Outlook on the web, sign out, and then sign in again as  **Kendra@yourdomain.hostdomain.com** with the password **Pa55w.rd**.
+18. On LON-CL2, in Outlook on the web, sign out, and then sign in again as  **Kendra@Adatumyyxxxxx.hostdomain.com**, where *yyxxxxx* is your unique Adatum number, with the password **Pa55w.rd**.
 
 19. On the Outlook page, select your time zone and click  **Save**.
 
@@ -357,7 +357,7 @@
 
 2. Click  **edit**.
 
-3. In the Exchange ActiveSync access settings window, click  **Quarantine - Let me** **decide to block or allow later**.
+3. In the Exchange ActiveSync access settings window, click  **Quarantine - Let me decide to block or allow later**.
 
 4. Under  **Quarantine Notification Email Messages**, click  **Add**, click  **Holly Spencer**, click  **add**, and then click  **OK**.
 


### PR DESCRIPTION
1. While not a problem in the lab, the use of **login.microsoftonline.com** in a production environment where the user has other Microsoft cloud services, could be a problem. 
2. Changed **yourdomain.hostdomain** to the agreed upon **adatumyyxxxxx.hostdomain.com**. 
3. Typos: a couple of misplaced spaces and added **escape character** before "**\***"s in the SPAM test strings.